### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/rpdoc/postman_response.rb
+++ b/lib/rpdoc/postman_response.rb
@@ -52,7 +52,7 @@ module Rpdoc
         data[:body] = JSON.pretty_generate(JSON.parse(@rspec_response.body)) rescue nil
       else
         body = @rspec_response.body
-        data[:body] = body.encoding.to_s == 'ASCII-8BIT' ? body.force_encoding("ISO-8859-1").encode("UTF-8") : body
+        data[:body] = body.encoding == Encoding::BINARY ? body.force_encoding(Encoding::ISO_8859_1).encode(Encoding::UTF_8) : body
       end
       data
     end


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576